### PR TITLE
Bugfix/invalid page param in search board

### DIFF
--- a/src/main/java/com/boardwe/boardwe/entity/Board.java
+++ b/src/main/java/com/boardwe/boardwe/entity/Board.java
@@ -68,7 +68,7 @@ public class Board {
     private Integer views;
 
     @Builder
-    public Board(BoardTheme boardTheme, String name, String description, String code, LocalDateTime writingStartTime, LocalDateTime writingEndTime, LocalDateTime openStartTime, LocalDateTime openEndTime, String password, OpenType openType, Integer views) {
+    public Board(Long id, BoardTheme boardTheme, String name, String description, String code, LocalDateTime writingStartTime, LocalDateTime writingEndTime, LocalDateTime openStartTime, LocalDateTime openEndTime, String password, OpenType openType, Integer views) {
         if (!(writingStartTime.isBefore(writingEndTime)
                 && writingEndTime.isBefore(openStartTime)
                 && openStartTime.isBefore(openEndTime)))
@@ -85,5 +85,6 @@ public class Board {
         this.password = password;
         this.openType = openType;
         this.views = views;
+        this.id = id;
     }
 }

--- a/src/main/java/com/boardwe/boardwe/entity/Board.java
+++ b/src/main/java/com/boardwe/boardwe/entity/Board.java
@@ -9,12 +9,16 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+
+import org.hibernate.annotations.DynamicUpdate;
+
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "BOARD")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicUpdate
 public class Board {
 
     @Id
@@ -68,7 +72,7 @@ public class Board {
     private Integer views;
 
     @Builder
-    public Board(Long id, BoardTheme boardTheme, String name, String description, String code, LocalDateTime writingStartTime, LocalDateTime writingEndTime, LocalDateTime openStartTime, LocalDateTime openEndTime, String password, OpenType openType, Integer views) {
+    public Board(BoardTheme boardTheme, String name, String description, String code, LocalDateTime writingStartTime, LocalDateTime writingEndTime, LocalDateTime openStartTime, LocalDateTime openEndTime, String password, OpenType openType, Integer views) {
         if (!(writingStartTime.isBefore(writingEndTime)
                 && writingEndTime.isBefore(openStartTime)
                 && openStartTime.isBefore(openEndTime)))
@@ -85,6 +89,9 @@ public class Board {
         this.password = password;
         this.openType = openType;
         this.views = views;
-        this.id = id;
+    }
+
+    public void increaseViews(){
+        views = views.intValue() + 1;
     }
 }

--- a/src/main/java/com/boardwe/boardwe/service/impl/BoardSearchServiceImpl.java
+++ b/src/main/java/com/boardwe/boardwe/service/impl/BoardSearchServiceImpl.java
@@ -36,7 +36,9 @@ public class BoardSearchServiceImpl implements BoardSearchService {
                 .toList();
         int start = (int) pageable.getOffset();
         int end = Math.min((start + pageable.getPageSize()), searchResults.size());
-        return new PageImpl<>(searchResults.subList(start, end), pageable, searchResults.size());
+        return (searchResults.size() > 0) ?
+            new PageImpl<>(searchResults.subList(start, end), pageable, searchResults.size()) :
+            new PageImpl<>(searchResults, pageable, searchResults.size());
     }
 
     @Override

--- a/src/main/java/com/boardwe/boardwe/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/boardwe/boardwe/service/impl/BoardServiceImpl.java
@@ -91,6 +91,8 @@ public class BoardServiceImpl implements BoardService {
 
         validateBoardStatus(boardStatus);
 
+        saveBoardWithIncreaseViews(board);
+
         return BoardReadResponseDto.builder()
                 .boardName(board.getName())
                 .boardDescription(board.getDescription())
@@ -243,5 +245,23 @@ public class BoardServiceImpl implements BoardService {
 
     private int getMemoCnt(Long boardId) {
         return memoRepository.findByBoardId(boardId).size();
+    }
+
+    private synchronized void saveBoardWithIncreaseViews(Board board){
+        boardRepository.saveAndFlush(Board.builder()
+                .id(board.getId())
+                .boardTheme(board.getBoardTheme())
+                .code(board.getCode())
+                .name(board.getName())
+                .description(board.getDescription())
+                .writingStartTime(board.getWritingStartTime())
+                .writingEndTime(board.getWritingEndTime())
+                .openStartTime(board.getOpenStartTime())
+                .openEndTime(board.getOpenEndTime())
+                .password(board.getPassword())
+                .openType(board.getOpenType())
+                .views((board.getViews().intValue() + 1))
+                .build()
+        );
     }
 }

--- a/src/main/java/com/boardwe/boardwe/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/boardwe/boardwe/service/impl/BoardServiceImpl.java
@@ -248,20 +248,7 @@ public class BoardServiceImpl implements BoardService {
     }
 
     private synchronized void saveBoardWithIncreaseViews(Board board){
-        boardRepository.saveAndFlush(Board.builder()
-                .id(board.getId())
-                .boardTheme(board.getBoardTheme())
-                .code(board.getCode())
-                .name(board.getName())
-                .description(board.getDescription())
-                .writingStartTime(board.getWritingStartTime())
-                .writingEndTime(board.getWritingEndTime())
-                .openStartTime(board.getOpenStartTime())
-                .openEndTime(board.getOpenEndTime())
-                .password(board.getPassword())
-                .openType(board.getOpenType())
-                .views((board.getViews().intValue() + 1))
-                .build()
-        );
+        board.increaseViews();
+        boardRepository.saveAndFlush(board);
     }
 }


### PR DESCRIPTION
### 작업 개요
1. 보드 조회시 조회수 증가 및 저장 기능 추가
2. last page보다 큰 page input시 빈 content와 page 정보를 response하도록 수정

### 작업 분류 (하나 선택)
- 신규 기능 및 버그 수정

### 작업 상세 내용
1. 보드 조회 서비스에 saveBoardWithIncreaseViews 메소드 추가
2. 보드 entity의 build pattern에 ID 추가(save함수 호출 시 update쿼리 실행을 위해)
3. last page보다 큰 page requestParam 값 입력시 빈 content와 page 정보를 반환하도록 수정

### 생각해볼 문제
보드 조회의 saveBoardWithIncreaseViews함수의 정책
1. synchronized로 조회수 증가와 저장까지 race condition방지. 동기화의 범위에 대해 팀원들의 이견이 있는지?
2. 조회수를 저장할 때 saveAndFlush 이용함 save vs saveAndFlush 논의 필요.
3. save함수는 즉시 flush를 하지 않아 성능상 이점 있으나 flush 전까지 보드의 조회수가 변경되지 않다가 한번에 변경됨. saveAndFlush는 매 보드 조회마다 변경된 조회수 값을 볼 수 있음.
