### PR TITLE
[hotfix] 로그인 및 메모/보드 삭제 시 HttpSession에서 제공하는 JSESSIONID를 사용하도록 수정

### DIFF
--- a/src/main/java/com/boardwe/boardwe/controller/BoardController.java
+++ b/src/main/java/com/boardwe/boardwe/controller/BoardController.java
@@ -6,10 +6,14 @@ import com.boardwe.boardwe.dto.req.BoardLoginRequestDto;
 import com.boardwe.boardwe.dto.res.BoardCreateResponseDto;
 import com.boardwe.boardwe.dto.res.BoardReadResponseDto;
 import com.boardwe.boardwe.dto.res.BoardSearchResponseDto;
+import com.boardwe.boardwe.exception.custom.other.InvalidAccessException;
+import com.boardwe.boardwe.exception.custom.other.InvalidPasswordException;
 import com.boardwe.boardwe.service.BoardSearchService;
 import com.boardwe.boardwe.service.BoardService;
 import com.boardwe.boardwe.service.LoginService;
+import com.boardwe.boardwe.type.SessionConst;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -20,6 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class BoardController {
@@ -62,13 +67,15 @@ public class BoardController {
     }
 
     @PostMapping("/board/login")
-    public ResponseEntity<Void> login(@RequestBody BoardLoginRequestDto boardLoginRequestDto, HttpServletResponse response, HttpSession session){
-        loginService.login(
-                boardLoginRequestDto.getBoardCode(),
-                boardLoginRequestDto.getPassword(),
-                response,
-                session
-        );
+    public ResponseEntity<Void> login(@RequestBody BoardLoginRequestDto boardLoginRequestDto, HttpSession session){
+        String boardCode = boardLoginRequestDto.getBoardCode();
+        Boolean canLogin = loginService.login(boardCode, boardLoginRequestDto.getPassword());
+        if (canLogin){
+            session.setAttribute(SessionConst.LOGIN_SESSION_ID, boardCode);
+            log.info("[BoardController] Login Succeed to board {}", boardCode);
+        } else {
+            throw new InvalidPasswordException();
+        }
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/boardwe/boardwe/controller/BoardController.java
+++ b/src/main/java/com/boardwe/boardwe/controller/BoardController.java
@@ -24,6 +24,8 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.util.List;
 
+import static com.boardwe.boardwe.type.SessionConst.LOGIN_SESSION_ID;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -45,8 +47,15 @@ public class BoardController {
     }
 
     @PostMapping("/board/{boardCode}/delete")
-    public ResponseEntity<Void> delete(@RequestBody BoardDeleteRequestDto boardDeleteRequestDto, @PathVariable String boardCode){
-        boardService.deleteBoard(boardDeleteRequestDto,boardCode);
+    public ResponseEntity<Void> delete(
+            @PathVariable String boardCode,
+            @SessionAttribute(name = LOGIN_SESSION_ID, required = false) String sessionValue
+            ){
+        if (sessionValue == null || !sessionValue.equals(boardCode)){
+            log.info("[BoardController] Invalid Session: {}", sessionValue);
+            throw new InvalidAccessException();
+        }
+        boardService.deleteBoard(boardCode);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/boardwe/boardwe/controller/MemoController.java
+++ b/src/main/java/com/boardwe/boardwe/controller/MemoController.java
@@ -9,6 +9,7 @@ import com.boardwe.boardwe.exception.ErrorCode;
 import com.boardwe.boardwe.exception.custom.CustomException;
 import com.boardwe.boardwe.exception.custom.other.InvalidAccessException;
 import com.boardwe.boardwe.service.MemoService;
+import com.boardwe.boardwe.type.SessionConst;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -19,6 +20,8 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpSession;
+
+import static com.boardwe.boardwe.type.SessionConst.LOGIN_SESSION_ID;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,19 +37,17 @@ public class MemoController {
     }
 
     @PostMapping("/board/{boardCode}/memo/delete")
-    public ResponseEntity<Void> deleteMemo(@RequestBody MemoDeleteRequestDto memoDeleteRequestDto, @PathVariable String boardCode, HttpSession session, @CookieValue(value = "boardWeSessionId", required = false)Cookie cookie){
-        String cookieValue = cookie.getValue();
-        log.info("cookie value" + cookieValue);
-        if(session.getAttribute(cookieValue) == null){
+    public ResponseEntity<Void> deleteMemo(
+            @RequestBody MemoDeleteRequestDto memoDeleteRequestDto,
+            @PathVariable String boardCode,
+            @SessionAttribute(name = LOGIN_SESSION_ID, required = false) String sessionValue
+    ){
+        if (sessionValue == null || !sessionValue.equals(boardCode)){
+            log.info("[MemoController] Invalid Session: {}", sessionValue);
             throw new InvalidAccessException();
         }
 
-        String sessionValue = (String) session.getAttribute(cookieValue);
-
-        if(!boardCode.equals(sessionValue)){
-            throw new InvalidAccessException();
-        }
-        memoService.deleteMemo(memoDeleteRequestDto,boardCode);
+        memoService.deleteMemo(memoDeleteRequestDto, boardCode);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/boardwe/boardwe/entity/Board.java
+++ b/src/main/java/com/boardwe/boardwe/entity/Board.java
@@ -26,7 +26,7 @@ public class Board {
     @Column(name = "board_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_theme_id")
     @NotNull
     private BoardTheme boardTheme;

--- a/src/main/java/com/boardwe/boardwe/entity/Tag.java
+++ b/src/main/java/com/boardwe/boardwe/entity/Tag.java
@@ -18,7 +18,7 @@ public class Tag {
     @Column(name = "tag_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id")
     @NotNull
     private Board board;

--- a/src/main/java/com/boardwe/boardwe/exception/ErrorCode.java
+++ b/src/main/java/com/boardwe/boardwe/exception/ErrorCode.java
@@ -4,17 +4,18 @@ public enum ErrorCode {
     // -------- 4xx --------
     REQUEST_ERROR(400,"잘못된 요청입니다."),
 
-    INVALID_ACCESS(400, "다시 로그인 후 이용해주세요."),
     // Invalid Input
     INVALID_INPUT_VALUE(400, "입력값이 유효하지 않습니다."),
     INVALID_DATE_VALUE(400, "날짜 순서가 유효하지 않습니다."),
-    INVALID_PASSWORD(400,"틀린 비밀번호 입니다."),
-    INVALID_MEMO_THEME_LIST(400, "메모리 리스트가 올바르지 않습니다."),
+    INVALID_MEMO_THEME_LIST(400, "메모 리스트가 올바르지 않습니다."),
+    MEMO_WITH_INVALID_BOARD(400,"보드에 속하지 않는 메모입니다."),
 
     // Entity Not Found
     ENTITY_NOT_FOUND(400, "해당 리소스가 존재하지 않습니다."),
     BOARD_NOT_FOUND(400, "해당 보드가 존재하지 않습니다."),
     IMAGE_INFO_NOT_FOUND(400, "해당 이미지 정보가 존재하지 않습니다."),
+    MEMO_NOT_FOUND(400,"메모를 찾을 수 없습니다."),
+    MEMO_THEME_NOT_FOUND(400,"메모 테마를 찾을 수 없습니다."),
 
     // About Board Status
     BOARD_BEFORE_WRITING(400, "롤링페이퍼 작성기간 이전입니다."),
@@ -30,14 +31,11 @@ public enum ErrorCode {
     UNABLE_TO_CREATE_DIRECTORY(400, "파일 디렉토리를 생성할 수 없습니다."),
     CANNOT_STORE_FILE(400,"파일을 저장할 수 없습니다."),
 
+    // login
+    INVALID_ACCESS(400, "잘못된 로그인 정보입니다."),
+    INVALID_PASSWORD(400,"틀린 비밀번호 입니다."),
 
     // -------- 5xx --------
-    MEMO_NOT_FOUND(400,"메모를 찾을 수 없습니다."),
-
-    MEMO_THEME_NOT_FOUND(400,"메모 테마를 찾을 수 없습니다."),
-
-    MEMO_WITH_INVALID_BOARD(400,"보드에 속하지 않는 메모입니다."),
-    //5xx
     INTERNAL_SERVER_ERROR(500,"서버에 문제가 발생했습니다.");
 
     private final int status;

--- a/src/main/java/com/boardwe/boardwe/service/BoardService.java
+++ b/src/main/java/com/boardwe/boardwe/service/BoardService.java
@@ -8,5 +8,5 @@ import com.boardwe.boardwe.dto.res.BoardReadResponseDto;
 public interface BoardService {
     BoardCreateResponseDto createBoard(BoardCreateRequestDto requestDto);
     BoardReadResponseDto readBoard(String boardCode);
-    void deleteBoard(BoardDeleteRequestDto requestDto, String boardCode);
+    void deleteBoard(String boardCode);
 }

--- a/src/main/java/com/boardwe/boardwe/service/LoginService.java
+++ b/src/main/java/com/boardwe/boardwe/service/LoginService.java
@@ -4,5 +4,5 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 public interface LoginService {
-    void login(String boardCode, String password, HttpServletResponse response, HttpSession session);
+    Boolean login(String boardCode, String password);
 }

--- a/src/main/java/com/boardwe/boardwe/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/boardwe/boardwe/service/impl/BoardServiceImpl.java
@@ -121,19 +121,13 @@ public class BoardServiceImpl implements BoardService {
 
     @Override
     @Transactional
-    public void deleteBoard(BoardDeleteRequestDto requestDto, String boardCode) {
+    public void deleteBoard(String boardCode) {
         log.info("[BoardServiceImpl] Delete board (board code: {}).", boardCode);
-        Board board = boardRepository.findByCode(boardCode).orElseThrow(BoardNotFoundException::new);
-
-        if (Objects.equals(board.getPassword(), requestDto.getPassword())) {
-            log.info("[BoardServiceImpl] Delete memos and tags of board.");
-            memoRepository.deleteByBoard(board);
-            tagRepository.deleteByBoard(board);
-            boardRepository.delete(board);
-        } else {
-            log.error("[BoardServiceImpl] Password is incorrect.");
-            throw new InvalidPasswordException();
-        }
+        Board board = boardRepository.findByCode(boardCode)
+                .orElseThrow(BoardNotFoundException::new);
+        memoRepository.deleteByBoard(board);
+        tagRepository.deleteByBoard(board);
+        boardRepository.delete(board);
     }
 
     private BoardTheme getBoardTheme(BoardCreateRequestDto createDto) {

--- a/src/main/java/com/boardwe/boardwe/service/impl/LoginServiceImpl.java
+++ b/src/main/java/com/boardwe/boardwe/service/impl/LoginServiceImpl.java
@@ -6,6 +6,7 @@ import com.boardwe.boardwe.exception.custom.entity.BoardNotFoundException;
 import com.boardwe.boardwe.exception.custom.other.InvalidPasswordException;
 import com.boardwe.boardwe.repository.BoardRepository;
 import com.boardwe.boardwe.service.LoginService;
+import com.boardwe.boardwe.type.SessionConst;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,19 +23,9 @@ public class LoginServiceImpl implements LoginService {
     private final BoardRepository boardRepository;
 
     @Override
-    public void login(String boardCode, String password, HttpServletResponse response, HttpSession session) {
-        Board board = boardRepository.findByCode(boardCode).orElseThrow(BoardNotFoundException::new);
-
-        if(!board.getPassword().equals(password)){
-            throw new InvalidPasswordException();
-        }
-
-        UUID sessionId = UUID.randomUUID();
-        Cookie cookie = new Cookie("boardWeSessionId", sessionId.toString());
-
-        cookie.setMaxAge(300);
-        response.addCookie(cookie);
-
-        session.setAttribute(sessionId.toString(), board.getCode());
+    public Boolean login(String boardCode, String password) {
+        Board board = boardRepository.findByCode(boardCode)
+                .orElseThrow(BoardNotFoundException::new);
+        return board.getPassword().equals(password);
     }
 }

--- a/src/main/java/com/boardwe/boardwe/type/SessionConst.java
+++ b/src/main/java/com/boardwe/boardwe/type/SessionConst.java
@@ -1,0 +1,5 @@
+package com.boardwe.boardwe.type;
+
+public interface SessionConst {
+    public static String LOGIN_SESSION_ID = "BOARDWE_LOGIN_SESSION_ID";
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 server:
+  port: 16383
   servlet:
     session:
-      timeout: 300
-  port: 16383
+      timeout: 300s
 
 spring:
   datasource:

--- a/src/test/java/com/boardwe/boardwe/service/impl/BoardDeleteTest.java
+++ b/src/test/java/com/boardwe/boardwe/service/impl/BoardDeleteTest.java
@@ -41,40 +41,14 @@ public class BoardDeleteTest {
     @DisplayName("보드를 삭제한다.")
     void deleteBoard(){
         String boardCode = "Test";
-        String password = "1234";
-
-        BoardDeleteRequestDto deleteBoard = BoardDeleteRequestDto.builder()
-                .password(password)
-                .build();
         Board board = mock(Board.class);
 
-        when(board.getPassword()).thenReturn("1234");
         when(boardRepository.findByCode(boardCode)).thenReturn(Optional.of(board));
         doNothing().when(memoRepository).deleteByBoard(board);
         doNothing().when(tagRepository).deleteByBoard(board);
         doNothing().when(boardRepository).delete(board);
 
-        boardService.deleteBoard(deleteBoard,boardCode);
-
-    }
-
-    @Test
-    @DisplayName("잘못된 비밀번호로 보드를 삭제할때 에러 처리")
-    void errorPasswordDeleteBoard(){
-        String boardCode = "Test";
-        String password = "1234";
-
-        BoardDeleteRequestDto deleteBoard = BoardDeleteRequestDto.builder()
-                .password(password)
-                .build();
-        Board board = mock(Board.class);
-
-        when(board.getPassword()).thenReturn("1235");
-        when(boardRepository.findByCode(boardCode)).thenReturn(Optional.of(board));
-
-        Assertions.assertThrows(InvalidPasswordException.class,()->{
-            boardService.deleteBoard(deleteBoard,boardCode);
-        });
+        boardService.deleteBoard(boardCode);
 
     }
 
@@ -82,17 +56,11 @@ public class BoardDeleteTest {
     @DisplayName("없는 보드를 삭제할 때 에러처리")
     void noBoardExceptionTest(){
         String boardCode = "Test";
-        String password = "1234";
-
-        BoardDeleteRequestDto deleteBoard = BoardDeleteRequestDto.builder()
-                .password(password)
-                .build();
-        Board board = mock(Board.class);
 
         when(boardRepository.findByCode(boardCode)).thenReturn(Optional.empty());
 
         Assertions.assertThrows(BoardNotFoundException.class,()->{
-            boardService.deleteBoard(deleteBoard,boardCode);
+            boardService.deleteBoard(boardCode);
         });
     }
 


### PR DESCRIPTION
### 작업 개요
- 로그인 및 메모/보드 삭제 시 HttpSession에서 제공하는 JSESSIONID를 사용하도록 수정

### 작업 분류
- 버그 수정
- 코드 개선

### 작업 상세 내용
- 별도로 쿠키를 생성하지 않고, HttpSession에서 기본적으로 제공하며 보편적으로 사용되는 JSESSIONID를 사용하도록 변경
- 보드 삭제 API도 비밀번호를 받는 방식에서 로그인 후 SESSION 확인하여 삭제하도록 수정
- Lazy Loading 안되어 있는 Entity Relation에 설정 추가
